### PR TITLE
Feature/step 01 lean functional programming : step01 함수형 프로그래밍 연습 구현 완료

### DIFF
--- a/src/main/java/nextstep/README.md
+++ b/src/main/java/nextstep/README.md
@@ -1,0 +1,208 @@
+# 람다
+
+---
+## 람다 실습 1 - 익명 클래스를 람다로 전환
+
+- 다음 테스트 코드에서 MoveStrategy에 대한 익명 클래스로 구현하고 있는데 람다를 적용해 구현한다.
+
+```java
+// nextstep.fp.CarTest의 이동, 정지 method
+public class CarTest {
+    @Test
+    public void 이동() {
+        Car car = new Car("pobi", 0);
+        Car actual = car.move(new MoveStrategy() {
+            @Override
+            public boolean isMovable() {
+                return true;
+            }
+        });
+        assertEquals(new Car("pobi", 1), actual);
+    }
+
+    @Test
+    public void 정지() {
+        Car car = new Car("pobi", 0);
+        Car actual = car.move(new MoveStrategy() {
+            @Override
+            public boolean isMovable() {
+                return false;
+            }
+        });
+        assertEquals(new Car("pobi", 0), actual);
+    }
+}
+```
+
+## 람다 실습 2 - 람다를 활용해 중복 제거
+
+```java
+// nextstep.fp.Lambda의 sumAll method
+List<Integer> numbers = Arrays.asList(1, 2, 3, 4, 5, 6);
+
+public int sumAll(List<Integer> numbers) {
+    int total = 0;
+    for (int number : numbers) {
+        total += number;
+    }
+    return total;
+}
+```
+
+```java
+// nextstep.fp.Lambda의 sumAllEven method
+List<Integer> numbers = Arrays.asList(1, 2, 3, 4, 5, 6);
+
+public int sumAllEven(List<Integer> numbers) {
+    int total = 0;
+    for (int number : numbers) {
+        if (number % 2 == 0) {
+            total += number;
+        }
+    }
+    return total;
+}
+```
+
+List에 담긴 값 중 3보다 큰 수만을 더해야 한다.
+이 기능을 구현하려고 보니 앞의 요구사항 1,2와 많은 중복이 발생한다. 람다를 활용해 중복을 제거한다.
+
+// nextstep.fp.Lambda의 sumAll, sumAllEven, sumAllOverThree method 소스 코드를 확인하고 중복 제거한다.
+
+#### 힌트
+- 변경되는 부분과 변경되지 않는 부분의 코드를 분리한다.
+- 변경되는 부분을 인터페이스로 추출한다.
+- 인터페이스에 대한 구현체를 익명 클래스(anonymous class)로 구현해 메소드의 인자로 전달한다.
+  - 구글에서 자바의 익명 클래스로 검색해 익명 클래스가 무엇인지 학습한다.
+- 인터페이스는 다음과 같은 형태로 추출할 수 있다.
+
+```java
+public interface Conditional {
+    boolean test(Integer number);
+}
+```
+
+- Conditional을 활용해 공통 메소드의 구조는 다음과 같다.
+```java
+public int sumAll(List<Integer> numbers,
+    Conditional c) {
+    // c.test(number)를 활용해 구현할 수 있다.
+}
+```
+- 익명 클래스를 자바 8의 람다를 활용해 구현한다.
+
+
+
+# 스트림(stream)
+
+---
+## map, filter, reduce
+Collection에 담긴 데이터를 처리하려면 Collection을 순회하면서 각 Element를 처리하는 것이 일반적이다. 앞으로는 순회하는 것을 잊고, Element 처리에만 집중하자.
+
+### filter
+요구사항은 파일 문자 중 길이가 12보다 큰 문자의 수를 구한다.
+```java
+// nextstep.fp.StreamStudy countWords method
+
+String contents = new String(Files.readAllBytes(
+  Paths.get("../ war-and-peace.txt")), StandardCharsets.UTF_8);
+List<String> words = Arrays.asList(contents.split("[\\P{L}]+"));
+
+long count = 0;
+for (String w : words) {
+  if (w.length() > 12) count++;  
+}
+```
+
+### filter 활용해 구현
+```java
+String contents = new String(Files.readAllBytes(
+  Paths.get("../alice.txt")), StandardCharsets.UTF_8);
+List<String> words = Arrays.asList(contents.split("[\\P{L}]+"));
+
+long count = 
+  words.stream().filter(w -> w.length() > 12).count();
+```
+
+### map
+List에 담긴 모든 숫자 값을 2배한 결과 List를 생성한다.
+```java
+// nextstep.fp.StreamStudy 클래스의 doubleNumbers method 참고
+List<Integer> numbers = Arrays.asList(1, 2, 3, 4, 5, 6);
+List<Integer> dobuleNumbers =
+  numbers.stream().map(x -> 2 * x).collect(Collectors.toList());
+```
+
+### reduce
+List에 담긴 모든 숫자의 합을 구한다.
+```java
+// nextstep.fp.StreamStudy 클래스의 sumAll method 참고
+
+List<Integer> numbers = Arrays.asList(1, 2, 3, 4, 5, 6);
+
+public int sumAll(List<Integer> numbers) {
+    return numbers.stream().reduce(0, (x, y) -> x + y);
+}
+```
+
+### 다양한 stream method 실습
+> src/main/resources/fp 디렉토리 아래에 있는 war-and-peace.txt 파일을 읽어 다음 요구사항을 만족하세요.
+
+### map, reduce, filter 실습 1
+List에 담긴 모든 숫자 중 3보다 큰 숫자를 2배 한 후 모든 값의 합을 구한다. 지금까지 학습한 map, reduce, filter를 활용해 구현해야 한다.
+- nextstep.fp.StreamStudyTest 클래스의 sumOverThreeAndDouble() 테스트를 pass해야 한다.
+
+### map, reduce, filter 실습 2
+nextstep.fp.StreamStudy 클래스의 printLongestWordTop100() 메서드를 구현한다. 요구사항은 다음과 같다.
+- 단어의 길이가 12자를 초과하는 단어를 추출한다.
+- 12자가 넘는 단어 중 길이가 긴 순서로 100개의 단어를 추출한다.
+- 단어 중복을 허용하지 않는다. 즉, 서로 다른 단어 100개를 추출해야 한다.
+- 추출한 100개의 단어를 출력한다. 모든 단어는 소문자로 출력해야 한다.
+
+#### 힌트
+- 단어의 길이가 12자를 초과하는 단어를 추출한다.
+- 12자가 넘는 단어 중 길이가 긴 순서로 100개의 단어를 추출한다.
+  - sorted() method 활용
+- 단어 중복을 허용하지 않는다. 즉, 서로 다른 단어 100개를 추출해야 한다.
+  - distinct() method 활용
+- 추출한 100개의 단어를 출력한다. 모든 단어는 소문자로 출력해야 한다.
+  - String.toLowerCase() method 활용
+
+
+
+# Optional
+
+---
+## 요구사항 1 - Optional을 활용해 조건에 따른 반환
+> nextstep.optional.User의 ageIsInRange1() 메소드는 30살 이상, 45살 이하에 해당하는 User가 존재하는 경우 true를 반환하는 메소드이다.
+>
+> 같은 기능을 Optional을 활용해 ageIsInRange2() 메소드에 구현한다. 메소드 인자로 받은 User를 Optional로 생성하면 stream의 map, filter와 같은 메소드를 사용하는 것이 가능하다.
+>
+> nextstep.optional.UserTest의 테스트가 모두 pass해야 한다.
+
+#### 힌트
+- [Guide To Java 8 Optional](https://www.baeldung.com/java-optional) 문서를 참고해 Optional 사용 방법을 익힌다.
+- Optional.ofNullable(user)을 활용해 User을 Optional로 생성하는 것이 가능하다.
+- Optional의 map(), filter() 메소드등을 활용해 필요한 데이터를 추출
+- Optional의 isPresent() 메소드 활용
+
+## 요구사항 2 - Optional에서 값을 반환
+> nextstep.optional.Users의 getUser() 메소드를 자바 8의 stream과 Optional을 활용해 구현한다.
+>
+> 자바 8의 stream과 Optional을 사용하도록 리팩토링한 후 UsersTest의 단위 테스트가 통과해야 한다.
+
+#### 힌트
+- [Guide To Java 8 Optional](https://www.baeldung.com/java-optional) 문서를 참고해 Optional 사용 방법을 익힌다.
+- Optional.ofNullable(user)을 활용해 User을 Optional로 생성하는 것이 가능하다.
+- Optional의 orElse() 메소드 활용해 구현한다.
+
+## 요구사항 3 - Optional에서 exception 처리
+> nextstep.optional.ExpressionTest의 테스트가 통과하도록 Expression의 of 메소드를 구현한다.
+>
+> 단, of 메소드를 구현할 때 자바 8의 stream을 기반으로 구현한다.
+
+#### 힌트
+- [Guide To Java 8 Optional](https://www.baeldung.com/java-optional) 문서를 참고해 Optional 사용 방법을 익힌다.
+- 자바의 enum 전체 값은 values() 메소드를 통해 배열로 접근 가능하다.
+- Arrays.stream()을 이용해 배열을 stream으로 생성할 수 있다.
+- 일치하는 값 하나를 추출할 때 findFirst() 메소드를 활용 가능하다.

--- a/src/main/java/nextstep/fp/Conditional.java
+++ b/src/main/java/nextstep/fp/Conditional.java
@@ -1,0 +1,6 @@
+package nextstep.fp;
+
+@FunctionalInterface
+public interface Conditional {
+	boolean test(Integer number);
+}

--- a/src/main/java/nextstep/fp/Lambda.java
+++ b/src/main/java/nextstep/fp/Lambda.java
@@ -26,31 +26,13 @@ public class Lambda {
         }).start();
     }
 
-    public static int sumAll(List<Integer> numbers) {
-        int total = 0;
-        for (int number : numbers) {
-            total += number;
-        }
-        return total;
-    }
-
-    public static int sumAllEven(List<Integer> numbers) {
-        int total = 0;
-        for (int number : numbers) {
-            if (number % 2 == 0) {
-                total += number;
-            }
-        }
-        return total;
-    }
-
-    public static int sumAllOverThree(List<Integer> numbers) {
-        int total = 0;
-        for (int number : numbers) {
-            if (number > 3) {
-                total += number;
-            }
-        }
-        return total;
-    }
+	public static int sum(List<Integer> numbers, Conditional conditional) {
+		int total = 0;
+		for (int number : numbers) {
+			if (conditional.test(number)) {
+				total += number;
+			}
+		}
+		return total;
+	}
 }

--- a/src/main/java/nextstep/fp/StreamStudy.java
+++ b/src/main/java/nextstep/fp/StreamStudy.java
@@ -38,7 +38,10 @@ public class StreamStudy {
         return numbers.stream().reduce(0, (x, y) -> x + y);
     }
 
-    public static long sumOverThreeAndDouble(List<Integer> numbers) {
-        return 0;
-    }
+	public static long sumOverThreeAndDouble(List<Integer> numbers) {
+		return numbers.stream()
+				.filter(number -> number > 3)
+				.map(number -> number * 2)
+				.reduce(0, (number1, number2) -> number1 + number2);
+	}
 }

--- a/src/main/java/nextstep/fp/StreamStudy.java
+++ b/src/main/java/nextstep/fp/StreamStudy.java
@@ -27,7 +27,15 @@ public class StreamStudy {
                 .get("src/main/resources/fp/war-and-peace.txt")), StandardCharsets.UTF_8);
         List<String> words = Arrays.asList(contents.split("[\\P{L}]+"));
 
-        // TODO 이 부분에 구현한다.
+	    List<String> longestWords = words.stream()
+			    .filter(word -> word.length() > 12)
+			    .distinct()
+			    .limit(100)
+			    .sorted((word1, word2) -> word2.length() - word1.length())
+			    .map(word -> word.toLowerCase())
+			    .collect(Collectors.toList());
+
+		longestWords.forEach(System.out::println);
     }
 
     public static List<Integer> doubleNumbers(List<Integer> numbers) {

--- a/src/main/java/nextstep/optional/User.java
+++ b/src/main/java/nextstep/optional/User.java
@@ -1,5 +1,7 @@
 package nextstep.optional;
 
+import java.util.Optional;
+
 public class User {
     private String name;
     private Integer age;
@@ -33,7 +35,9 @@ public class User {
     }
 
     public static boolean ageIsInRange2(User user) {
-        return false;
+        return Optional.ofNullable(user)
+                .filter(u -> u.getAge() != null && (u.getAge() >= 30 && u.getAge() <= 45))
+                .isPresent();
     }
 
     @Override

--- a/src/main/java/nextstep/optional/Users.java
+++ b/src/main/java/nextstep/optional/Users.java
@@ -13,11 +13,9 @@ public class Users {
             new User("honux", 45));
 
     User getUser(String name) {
-        for (User user : users) {
-            if (user.matchName(name)) {
-                return user;
-            }
-        }
-        return DEFAULT_USER;
+        return users.stream()
+                .filter(user -> user.matchName(name))
+                .findFirst()
+                .orElse(DEFAULT_USER);
     }
 }

--- a/src/test/java/nextstep/fp/CarTest.java
+++ b/src/test/java/nextstep/fp/CarTest.java
@@ -8,24 +8,14 @@ public class CarTest {
     @Test
     public void 이동() {
         Car car = new Car("pobi", 0);
-        Car actual = car.move(new MoveStrategy() {
-            @Override
-            public boolean isMovable() {
-                return true;
-            }
-        });
+        Car actual = car.move(() -> true);
         assertThat(actual).isEqualTo(new Car("pobi", 1));
     }
 
     @Test
     public void 정지() {
         Car car = new Car("pobi", 0);
-        Car actual = car.move(new MoveStrategy() {
-            @Override
-            public boolean isMovable() {
-                return false;
-            }
-        });
+        Car actual = car.move(() -> false);
         assertThat(actual).isEqualTo(new Car("pobi", 0));
     }
 }

--- a/src/test/java/nextstep/fp/LambdaTest.java
+++ b/src/test/java/nextstep/fp/LambdaTest.java
@@ -9,43 +9,44 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class LambdaTest {
-    private List<Integer> numbers;
 
-    @BeforeEach
-    public void setup() {
-        numbers = Arrays.asList(1, 2, 3, 4, 5, 6);
-    }
+	private List<Integer> numbers;
 
-    @Test
-    public void printAllOld() throws Exception {
-        Lambda.printAllOld(numbers);
-    }
+	@BeforeEach
+	public void setup() {
+		numbers = Arrays.asList(1, 2, 3, 4, 5, 6);
+	}
 
-    @Test
-    public void printAllLambda() throws Exception {
-        Lambda.printAllLambda(numbers);
-    }
+	@Test
+	public void printAllOld() throws Exception {
+		Lambda.printAllOld(numbers);
+	}
 
-    @Test
-    public void runThread() throws Exception {
-        Lambda.runThread();
-    }
+	@Test
+	public void printAllLambda() throws Exception {
+		Lambda.printAllLambda(numbers);
+	}
 
-    @Test
-    public void sumAll() throws Exception {
-        int sum = Lambda.sumAll(numbers);
-        assertThat(sum).isEqualTo(21);
-    }
+	@Test
+	public void runThread() throws Exception {
+		Lambda.runThread();
+	}
 
-    @Test
-    public void sumAllEven() throws Exception {
-        int sum = Lambda.sumAllEven(numbers);
-        assertThat(sum).isEqualTo(12);
-    }
+	@Test
+	public void sumAll() throws Exception {
+		int sum = Lambda.sum(numbers, (number) -> true);
+		assertThat(sum).isEqualTo(21);
+	}
 
-    @Test
-    public void sumAllOverThree() throws Exception {
-        int sum = Lambda.sumAllOverThree(numbers);
-        assertThat(sum).isEqualTo(15);
-    }
+	@Test
+	public void sumAllEven() throws Exception {
+		int sum = Lambda.sum(numbers, (number) -> number % 2 == 0);
+		assertThat(sum).isEqualTo(12);
+	}
+
+	@Test
+	public void sumAllOverThree() throws Exception {
+		int sum = Lambda.sum(numbers, (number) -> number > 3);
+		assertThat(sum).isEqualTo(15);
+	}
 }

--- a/src/test/java/nextstep/optional/UsersTest.java
+++ b/src/test/java/nextstep/optional/UsersTest.java
@@ -10,6 +10,7 @@ public class UsersTest {
     public void getUser() {
         Users users = new Users();
         assertThat(users.getUser("crong")).isEqualTo(new User("crong", 35));
+        assertThat(users.getUser("jk")).isEqualTo(new User("jk", 40));
     }
 
 
@@ -17,5 +18,7 @@ public class UsersTest {
     public void getDefaultUser() {
         Users users = new Users();
         assertThat(users.getUser("codesquard")).isEqualTo(Users.DEFAULT_USER);
+        assertThat(users.getUser("")).isEqualTo(Users.DEFAULT_USER);
+        assertThat(users.getUser(null)).isEqualTo(Users.DEFAULT_USER);
     }
 }


### PR DESCRIPTION
## 회고

### 람다
```java
@FunctionalInterface
public interface Conditional {
	boolean test(Integer number);
}
```
해당 코드는 함수형 인터페이스의 선언부이다. 
그런데 람다를 학습하면서 자연스럽게 스트림의 filter() 메서드를 알게 되었고, filter() 의 파라미터인
Predicate 함수형 인터페이스 역시 알게되었다. 
Predicate는 Conditional 처럼 단 하나의 test() 추상 메서드를 가지며, 해당 메서드는 boolean 값을 리턴한다.
또한 test() 메서드는 파라미터를 제너릭으로 받고 있고, default, static 등으로 구현된 메서드도 가지고 있다.
여기서 중요한점은 Predicate 가 있는데 굳이 Conditional 를 만들 필요가 있냐는 것이다.
해당 챕터에서는 학습을 목적으로 Conditional 가 생성되었지만, 실제 개발을 할 때 별도의 함수형 인터페이스를 만들지 않고
이미 존재하는 인터페이스를 사용하는 것이 더 나은 판단이 아닐까 하는 생각이 들었다.
[함수형 인터페이스 표준 API](https://inpa.tistory.com/entry/%E2%98%95-%ED%95%A8%EC%88%98%ED%98%95-%EC%9D%B8%ED%84%B0%ED%8E%98%EC%9D%B4%EC%8A%A4-API)

### 스트림
```java
    static final User DEFAULT_USER = new User("codesquad", 100);

    List<User> users = Arrays.asList(
            new User("crong", 35),
            new User("pobi", 30),
            new User("jk", 40),
            new User("honux", 45));

    User getUser(String name) {
        return users.stream()
                .filter(user -> user.matchName(name))
                .findFirst();
}
```
해당 코드는 컴파일 단계에서 에러가 발생한다. 이유는 스트림의 `findFirst()` 메서드가 `User`가 아닌 `Optional<User>` 객체를 리턴하기 때문이다. 그렇기에 
```java
    User getUser(String name) {
        return users.stream()
                .filter(user -> user.matchName(name))
                .findFirst().get();
```
이렇게 `get()`을 사용해서 `User` 객체를 전달해야 한다.

이때 `get()` 대신 `orElse()`을 사용하면, 값을 포함하고 있지 않은 경우 인자로 지정한 `User `객체를 리턴한다. (여기서는 DEFAULT_USER 로 지정했다.)
즉 `orElse()`는 기본적으로 `get()`의 기능을 포함하고 있는 Optional의 메서드인 것이다.

그렇기에 `get()` 의 사용은 일반적으로 권장되지 않는다. 이는 Optional의 사용 목적에 부합하지 않기 때문이다.

`orElse()` 외에 `orElseGet()` 나 `orElseThrow()`를 사용하는 것도 가능하다.

`orElseGet()`는 `orElse()`와 달리 해당 값이 비어 있을 경우에만 로직이 수행된다. 즉, `orElse()`의 경우 값이 존재하는 경우에도 실행된다는 것이다. 그렇기에 굳이 객체를 생성할 필요 없이 `orElseGet()`를 사용하여 처리하려 했으나
![image](https://github.com/PhiloMonx1/java-blackjack-playground/assets/99243066/494bede7-18ed-4075-a808-45fe84ddd341)
이렇게 "과도한 람다 사용" 이라는 IDE의 경고를 받았다.
이유는 이미 선언된 `DEFAULT_USER` 를 사용하면서 `() ->` 이라는 불필요한 람다의 선언이 발생했기 때문이다. `orElseGet()`을 쓰는 이유는 값이 비어 있을 경우에만 디폴트로 지정된 `User` 객체를 생성하기 위해서 인데, 이미 static 으로 선언된 클래스 상수가 있는 이상 사용 목적이 의미가 없다.

```
    User getUser(String name) {
        return users.stream()
                .filter(user -> user.matchName(name))
                .findFirst()
                .orElseGet(() -> new User("codesquad", 100));
    }
```
그렇기에 이렇게 새로운 객체를 생성하도록 바꿔주면 IDE의 경고가 사라진다.
다만 나는 이미 존재하는 `DEFAULT_USER` 상수를 삭제하는 것은 가독성이 떨어진다는 생각이 들어서 그냥 `orElse()`를 사용했다.

`orElseThrow` 는
```
String result = Optional.ofNullable(null)
                .orElseThrow(() -> new IllegalArgumentException("값이 없습니다."));
```
이렇게 예외 처리를 하는 목적으로 사용된다.